### PR TITLE
Fix regexes to correctly check branch length

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,60 @@
+name: 'semver-action'
+description: 'Generate a semantic version'
+
+branding:
+  color: purple
+  icon: tag
+
+inputs:
+  bump:
+    description: 'Bump strategy for semantic versioning. Can be `auto`, `major`, `minor`, `patch`'
+    default: 'auto'
+    required: false
+  base_version:
+    description: 'Version to use as base for the generation, skips version bumps.'
+    required: false
+  prefix:
+    description: 'Prefix used to prepend the final version'
+    default: 'v'
+    required: false
+  prerelease_id:
+    description: 'Text representing the pre-release identifier'
+    default: 'pre'
+    required: false
+  main_branch_name:
+    description: 'The main branch name'
+    default: 'master'
+    required: false
+  develop_branch_name:
+    description: 'The develop branch name'
+    default: 'develop'
+    required: false
+  repo_dir:
+    description: 'The repository path'
+    default: 'current dir'
+    required: false
+  debug:
+    description: 'Enables debug mode'
+    default: 'false'
+    required: false
+    
+outputs:
+  semver_tag:
+    description: 'The calculdated semantic version'
+  is_prerelease:
+    description: 'True if calculated tag is pre-release'
+  previous_tag:
+    description: 'The tag used to calculate next semantic version'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.bump }}
+    - ${{ inputs.base_version }}
+    - ${{ inputs.prefix }}
+    - ${{ inputs.prerelease_id }}
+    - ${{ inputs.main_branch_name }}
+    - ${{ inputs.develop_branch_name }}
+    - ${{ inputs.repo_dir }}
+    - ${{ inputs.debug }}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -13,13 +13,13 @@ import (
 
 var (
 	// nolint
-	branchHotfixPrefixRegex = regexp.MustCompile(`(?i)^hotfix(es)?/.*`)
+	branchHotfixPrefixRegex = regexp.MustCompile(`(?i)^hotfix(es)?/.+`)
 	// nolint
-	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature(s)?/.*`)
+	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature(s)?/.+`)
 	// nolint
-	branchBugfixPrefixRegex = regexp.MustCompile(`(?i)^bugfix(es)?/.*`)
+	branchBugfixPrefixRegex = regexp.MustCompile(`(?i)^bugfix(es)?/.+`)
 	// nolint
-	branchMajorPrefixRegex = regexp.MustCompile(`(?i)^major/.*`)
+	branchMajorPrefixRegex = regexp.MustCompile(`(?i)^major/.+`)
 )
 
 const tagDefault = "0.0.0"


### PR DESCRIPTION
This PR replaces `star` into regex to `plus` sign to guarantee ate least one branch name is given. It also adds `action.yml` to avoid warning at runtime.

<img width="839" alt="Screen Shot 2021-03-28 at 00 49 37" src="https://user-images.githubusercontent.com/782854/112741865-3a6bc480-8f57-11eb-9c1c-308160feec55.png">
