### PR TITLE
Add ancestor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ Uses `auto` bump strategy to calculate the next semantic version.
 
 ## Outpus
 
-| parameter           | description                                      |
-| ---                 | ---                                              |
-| semver_tag          | The calculdated semantic version.                |
-| is_prerelease       | True if calculated tag is pre-release.           |
-| previous_tag        | The tag used to calculate next semantic version. |
+| parameter     | description                                      |
+| ---           | ---                                              |
+| semver_tag    | The calculdated semantic version.                |
+| is_prerelease | True if calculated tag is pre-release.           |
+| previous_tag  | The tag used to calculate next semantic version. |
+| ancestor_tag  | The ancestor tag based on specific pattern.      |

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,8 @@ outputs:
     description: 'True if calculated tag is pre-release'
   previous_tag:
     description: 'The tag used to calculate next semantic version'
+  ancestor_tag:
+    description: 'The ancestor tag based on specific pattern'
 
 runs:
   using: 'docker'

--- a/main.go
+++ b/main.go
@@ -24,6 +24,10 @@ func main() {
 	log.Infof("PREVIOUS_TAG: %s", result.PreviousTag)
 	fmt.Printf("::set-output name=PREVIOUS_TAG::%s\n", result.PreviousTag)
 
+	// Print ancestor tag.
+	log.Infof("ANCESTOR_TAG: %s", result.AncestorTag)
+	fmt.Printf("::set-output name=ANCESTOR_TAG::%s\n", result.AncestorTag)
+
 	// Print calculated semver tag.
 	log.Infof("SEMVER_TAG: %s", result.SemverTag)
 	fmt.Printf("::set-output name=SEMVER_TAG::%s\n", result.SemverTag)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -151,3 +151,22 @@ func (c *Client) LatestTag(prefix string) (*semver.Version, error) {
 
 	return nil, nil
 }
+
+// AncestorTag returns the previous tag that matches specific pattern if found.
+func (c *Client) AncestorTag(prefix, pattern string) (*semver.Version, error) {
+	var (
+		prefixRe = regexp.MustCompile(fmt.Sprintf("^%s", prefix))
+	)
+
+	tagStr, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", pattern))
+	if tagStr != "" {
+		tagStr = prefixRe.ReplaceAllLiteralString(tagStr, "")
+		parsed, err := semver.Parse(tagStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tag %q or not valid semantic version: %s", tagStr, err)
+		}
+		return &parsed, nil
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
This PR prints the previous matching tag if found. It's a preparation for changelog action to correcttly print the changelog based on what's already merged to the branch.

Let's think this scenario where tags are:
- v2.0.0
- v2.0.0-dev.1
- v1.0.0
- v1.0.0-dev.1
- v0.1.2-dev.1
- v0.1.1-dev.1
- v0.1.0-dev.1

Before adding this feature we only had `previous tag` returning `v2.0.0-dev.1` for master branch and there wasn't no way to actually return the previous tag for master. In this proposal it will return `v1.0.0` which is useful for Changelog to correctly print all commits between `v1.0.0` and `v2.0.0` instead of only printing the commits between `v2.0.0-dev.1` and `v2.0.0`.