### PR TITLE
Update branch patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ If `auto` bump, it will try to extract the closest tag and calculate the next se
 
 These are the prefixes we expect when `auto` bump:
 
-- `^bugfix(es)?/.*` or `^hotfix(es)?/.*` - `patch`
+- `^bugfix/.*` or `^hotfix/.*` - `patch`
 - `^doc/.*` - `build`
-- `^feature(s)?/.*` - `minor`
+- `^feature/.*` - `minor`
 - `^major/.*` - `major`
 - `^misc/.*` - `build`
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If `auto` bump, it will try to extract the closest tag and calculate the next se
 These are the prefixes we expect when `auto` bump:
 
 - `^bugfix(es)?/.*` or `^hotfix(es)?/.*` - `patch`
+- `^doc/.*` - `build`
 - `^feature(s)?/.*` - `minor`
 - `^major/.*` - `major`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ These are the prefixes we expect when `auto` bump:
 - `^doc/.*` - `build`
 - `^feature(s)?/.*` - `minor`
 - `^major/.*` - `major`
+- `^misc/.*` - `build`
 
 ### Scenarios
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -11,15 +11,13 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+// nolint: gochecknoglobals
 var (
-	// nolint
-	branchHotfixPrefixRegex = regexp.MustCompile(`(?i)^hotfix(es)?/.+`)
-	// nolint
+	branchBugfixPrefixRegex  = regexp.MustCompile(`(?i)^bugfix(es)?/.+`)
+	branchDocPrefixRegex     = regexp.MustCompile(`(?i)^doc/.+`)
 	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature(s)?/.+`)
-	// nolint
-	branchBugfixPrefixRegex = regexp.MustCompile(`(?i)^bugfix(es)?/.+`)
-	// nolint
-	branchMajorPrefixRegex = regexp.MustCompile(`(?i)^major/.+`)
+	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^hotfix(es)?/.+`)
+	branchMajorPrefixRegex   = regexp.MustCompile(`(?i)^major/.+`)
 )
 
 const tagDefault = "0.0.0"
@@ -201,6 +199,11 @@ func determineBumpStrategy(bump, sourceBranch, destBranch, mainBranchName, devel
 	// bugfix into develop branch
 	if branchBugfixPrefixRegex.MatchString(sourceBranch) && destBranch == developBranchName {
 		return "build", "patch"
+	}
+
+	// doc into develop branch
+	if branchDocPrefixRegex.MatchString(sourceBranch) && destBranch == developBranchName {
+		return "build", ""
 	}
 
 	// feature into develop

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -18,6 +18,7 @@ var (
 	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature(s)?/.+`)
 	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^hotfix(es)?/.+`)
 	branchMajorPrefixRegex   = regexp.MustCompile(`(?i)^major/.+`)
+	branchMiscPrefixRegex    = regexp.MustCompile(`(?i)^misc/.+`)
 )
 
 const tagDefault = "0.0.0"
@@ -214,6 +215,11 @@ func determineBumpStrategy(bump, sourceBranch, destBranch, mainBranchName, devel
 	// major into develop
 	if branchMajorPrefixRegex.MatchString(sourceBranch) && destBranch == developBranchName {
 		return "build", "major"
+	}
+
+	// misc into develop branch
+	if branchMiscPrefixRegex.MatchString(sourceBranch) && destBranch == developBranchName {
+		return "build", ""
 	}
 
 	// hotfix into main branch

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -13,10 +13,10 @@ import (
 
 // nolint: gochecknoglobals
 var (
-	branchBugfixPrefixRegex  = regexp.MustCompile(`(?i)^bugfix(es)?/.+`)
+	branchBugfixPrefixRegex  = regexp.MustCompile(`(?i)^bugfix/.+`)
 	branchDocPrefixRegex     = regexp.MustCompile(`(?i)^doc/.+`)
-	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature(s)?/.+`)
-	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^hotfix(es)?/.+`)
+	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature/.+`)
+	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^hotfix/.+`)
 	branchMajorPrefixRegex   = regexp.MustCompile(`(?i)^major/.+`)
 	branchMiscPrefixRegex    = regexp.MustCompile(`(?i)^misc/.+`)
 )

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -21,6 +21,13 @@ func TestDetermineBumpStrategy(t *testing.T) {
 			ExpectedMethod:  "build",
 			ExpectedVersion: "patch",
 		},
+		"source branch doc, dest branch develop and auto bump": {
+			SourceBranch:    "doc/some",
+			DestBranch:      "develop",
+			Bump:            "auto",
+			ExpectedMethod:  "build",
+			ExpectedVersion: "",
+		},
 		"source branch feature, dest branch develop and auto bump": {
 			SourceBranch:    "feature/some",
 			DestBranch:      "develop",

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -42,6 +42,13 @@ func TestDetermineBumpStrategy(t *testing.T) {
 			ExpectedMethod:  "build",
 			ExpectedVersion: "major",
 		},
+		"source branch misc, dest branch develop and auto bump": {
+			SourceBranch:    "misc/some",
+			DestBranch:      "develop",
+			Bump:            "auto",
+			ExpectedMethod:  "build",
+			ExpectedVersion: "",
+		},
 		"source branch hotfix, dest branch master and auto bump": {
 			SourceBranch:   "hotfix/some",
 			DestBranch:     "master",

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -72,6 +72,24 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
+		"misc branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "0.2.1-alpha.1",
+			SourceBranch:  "misc/semver-initial",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1-alpha.1",
+				SemverTag:    "v0.2.1-alpha.2",
+				IsPrerelease: true,
+			},
+		},
 		"merge develop into master": {
 			CurrentBranch: "master",
 			LatestTag:     "1.4.17-alpha.1",

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -36,6 +36,24 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
+		"doc branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "0.2.1-alpha.1",
+			SourceBranch:  "doc/semver-initial",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1-alpha.1",
+				SemverTag:    "v0.2.1-alpha.2",
+				IsPrerelease: true,
+			},
+		},
 		"feature branch into develop": {
 			CurrentBranch: "develop",
 			LatestTag:     "0.2.1",


### PR DESCRIPTION
This PR updates branch patterns:

- Add `doc/...` branch pattern for documentation related changes. (will not bump versions, but do a prerelease increment)
- Add `misc/...` branch pattern for other non-source-code related changes. (will not bump versions, but do a prerelease increment)
- Remove plural branch patterns, as our contributing guidelines explicitly states, that "Each pull request should address a single bug fix or feature." (https://github.com/wakatime/wakatime-cli/blame/develop/CONTRIBUTING.md#L40)

The adjustment is done in semver repo, as our contributing guidelines refer to semver documentation regarding branch naming (https://github.com/wakatime/wakatime-cli/blame/develop/CONTRIBUTING.md#L31)
  
Addresses https://github.com/wakatime/wakatime-cli/issues/349