### PR TITLE
Fix git commands

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -26,8 +26,8 @@ const tagDefault = "0.0.0"
 type gitClient interface {
 	CurrentBranch() (string, error)
 	IsRepo() bool
-	LatestTag() (string, error)
-	AncestorTag(include, exclude string) (string, error)
+	LatestTag() string
+	AncestorTag(include, exclude string) string
 	SourceBranch(commitHash string) (string, error)
 }
 
@@ -88,16 +88,12 @@ func Tag(params Params, gc gitClient) (Result, error) {
 
 	log.Debugf("method: %q, version: %q", method, version)
 
-	latestTag, err := gc.LatestTag()
-	if err != nil {
-		return Result{}, fmt.Errorf("failed getting latest tag: %s", err)
-	}
-
 	var (
 		tag      *semver.Version
 		prefixRe = regexp.MustCompile(fmt.Sprintf("^%s", params.Prefix))
 	)
 
+	latestTag := gc.LatestTag()
 	if latestTag == "" {
 		tag, _ = semver.New(tagDefault)
 	} else {
@@ -190,10 +186,7 @@ func Tag(params Params, gc gitClient) (Result, error) {
 		finalTag = params.Prefix + tag.FinalizeVersion()
 	}
 
-	ancestorTag, err = gc.AncestorTag(includePattern, excludePattern)
-	if err != nil {
-		return Result{}, fmt.Errorf("failed getting ancestor tag: %s", err)
-	}
+	ancestorTag = gc.AncestorTag(includePattern, excludePattern)
 
 	return Result{
 		PreviousTag:  previousTag,

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -278,9 +278,9 @@ type gitClientMock struct {
 	CurrentBranchFnInvoked int
 	IsRepoFn               func() bool
 	IsRepoFnInvoked        int
-	LatestTagFn            func() (string, error)
+	LatestTagFn            func() string
 	LatestTagFnInvoked     int
-	AncestorTagFn          func(include, exclude string) (string, error)
+	AncestorTagFn          func(include, exclude string) string
 	AncestorTagFnInvoked   int
 	SourceBranchFn         func(commitHash string) (string, error)
 	SourceBranchFnInvoked  int
@@ -294,11 +294,11 @@ func initGitClientMock(t *testing.T, latestTag, ancestorTag, currentBranch, sour
 		IsRepoFn: func() bool {
 			return true
 		},
-		LatestTagFn: func() (string, error) {
-			return latestTag, nil
+		LatestTagFn: func() string {
+			return latestTag
 		},
-		AncestorTagFn: func(include, exclude string) (string, error) {
-			return ancestorTag, nil
+		AncestorTagFn: func(include, exclude string) string {
+			return ancestorTag
 		},
 		SourceBranchFn: func(commitHash string) (string, error) {
 			assert.Equal(t, expectedCommitHash, commitHash)
@@ -316,12 +316,12 @@ func (m *gitClientMock) IsRepo() bool {
 	return m.IsRepoFn()
 }
 
-func (m *gitClientMock) LatestTag() (string, error) {
+func (m *gitClientMock) LatestTag() string {
 	m.LatestTagFnInvoked += 1
 	return m.LatestTagFn()
 }
 
-func (m *gitClientMock) AncestorTag(include, exclude string) (string, error) {
+func (m *gitClientMock) AncestorTag(include, exclude string) string {
 	m.AncestorTagFnInvoked += 1
 	return m.AncestorTagFn(include, exclude)
 }

--- a/cmd/generate/params.go
+++ b/cmd/generate/params.go
@@ -139,8 +139,8 @@ func (p Params) String() string {
 
 	return fmt.Sprintf(
 		"commit sha: %q, bump: %q, base version: %q, prefix: %q,"+
-			" prerelease id: %q, main branch name: %s, develop branch name: %s,"+
-			" repo dir: %s, debug: %t\n",
+			" prerelease id: %q, main branch name: %q, develop branch name: %q,"+
+			" repo dir: %q, debug: %t\n",
 		p.CommitSha,
 		p.Bump,
 		baseVersion,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -124,19 +124,19 @@ func (c *Client) SourceBranch(commitHash string) (string, error) {
 }
 
 // LatestTag returns the latest tag if found.
-func (c *Client) LatestTag() (string, error) {
-	result, err := c.Clean(c.Run("-C", c.repoDir, "tag", "--points-at", "HEAD", "--sort", "-version:creatordate"))
-	if err != nil {
-		return c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0"))
+func (c *Client) LatestTag() string {
+	result, _ := c.Clean(c.Run("-C", c.repoDir, "tag", "--points-at", "HEAD", "--sort", "-version:creatordate"))
+	if result == "" {
+		result, _ = c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0"))
 	}
-	return result, err
+	return result
 }
 
 // AncestorTag returns the previous tag that matches specific pattern if found.
-func (c *Client) AncestorTag(include, exclude string) (string, error) {
-	result, err := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, "--exclude", exclude))
-	if err != nil {
-		return c.Clean(c.Run("-C", c.repoDir, "rev-list", "--max-parents=0", "HEAD"))
+func (c *Client) AncestorTag(include, exclude string) string {
+	result, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, "--exclude", exclude))
+	if result == "" {
+		result, _ = c.Clean(c.Run("-C", c.repoDir, "rev-list", "--max-parents=0", "HEAD"))
 	}
-	return result, err
+	return result
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -113,8 +113,7 @@ func TestLatestTag(t *testing.T) {
 		return "v2.4.79", nil
 	}
 
-	value, err := gc.LatestTag()
-	require.NoError(t, err)
+	value := gc.LatestTag()
 
 	assert.Equal(t, "v2.4.79", value)
 }
@@ -138,8 +137,7 @@ func TestLatestTag_NoTagFound(t *testing.T) {
 		return "", nil
 	}
 
-	value, err := gc.LatestTag()
-	require.NoError(t, err)
+	value := gc.LatestTag()
 
 	assert.Empty(t, value)
 }
@@ -171,8 +169,7 @@ func TestAncestorTag(t *testing.T) {
 				return test.ExpectedTag, nil
 			}
 
-			value, err := gc.AncestorTag(test.IncludePattern, test.ExcludePattern)
-			require.NoError(t, err)
+			value := gc.AncestorTag(test.IncludePattern, test.ExcludePattern)
 
 			assert.Equal(t, test.ExpectedTag, value)
 		})
@@ -198,8 +195,7 @@ func TestAncestorTag_NoTagFound(t *testing.T) {
 		return "", nil
 	}
 
-	value, err := gc.AncestorTag("", "")
-	require.NoError(t, err)
+	value := gc.AncestorTag("", "")
 
 	assert.Empty(t, value)
 }


### PR DESCRIPTION
This PR fixes `LatestTag` and `AncestorTag` funcs to correctly validate for string empty.