### PR TITLE
Add new conditional for resync prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These are the prefixes we expect when `auto` bump:
 - `^feature/.*` - `minor`
 - `^major/.*` - `major`
 - `^misc/.*` - `build`
+- `^resync/.*` - Special case needed to resync base branch into develop when hotfix gets merged into base - Mostly from `master` into `develop`.
 
 ### Scenarios
 

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -55,6 +55,13 @@ func TestDetermineBumpStrategy(t *testing.T) {
 			Bump:           "auto",
 			ExpectedMethod: "hotfix",
 		},
+		"source branch resync, dest branch develop and auto bump": {
+			SourceBranch:    "resync/some",
+			DestBranch:      "develop",
+			Bump:            "auto",
+			ExpectedMethod:  "build",
+			ExpectedVersion: "patch",
+		},
 		"source branch develop, dest branch master and auto bump": {
 			SourceBranch:   "develop",
 			DestBranch:     "master",

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -93,6 +93,24 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
+		"bugfix branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "v0.2.1",
+			SourceBranch:  "bugfix/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				SemverTag:    "v0.2.2-alpha.1",
+				IsPrerelease: true,
+			},
+		},
 		"misc branch into develop": {
 			CurrentBranch: "develop",
 			LatestTag:     "v0.2.1-alpha.1",

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -3,10 +3,11 @@ package generate_test
 import (
 	"testing"
 
+	"github.com/wakatime/semver-action/cmd/generate"
+
 	"github.com/alecthomas/assert"
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
-	"github.com/wakatime/semver-action/cmd/generate"
 )
 
 func TestTag(t *testing.T) {
@@ -20,7 +21,7 @@ func TestTag(t *testing.T) {
 	}{
 		"no previous tag": {
 			CurrentBranch: "develop",
-			SourceBranch:  "major/semver-initial",
+			SourceBranch:  "major/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",
@@ -38,7 +39,7 @@ func TestTag(t *testing.T) {
 		},
 		"first non-development tag": {
 			CurrentBranch: "master",
-			LatestTag:     "1.0.0-alpha.1",
+			LatestTag:     "v1.0.0-alpha.1",
 			AncestorTag:   "e63c125b",
 			SourceBranch:  "develop",
 			Params: generate.Params{
@@ -58,8 +59,8 @@ func TestTag(t *testing.T) {
 		},
 		"doc branch into develop": {
 			CurrentBranch: "develop",
-			LatestTag:     "0.2.1-alpha.1",
-			SourceBranch:  "doc/semver-initial",
+			LatestTag:     "v0.2.1-alpha.1",
+			SourceBranch:  "doc/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",
@@ -76,8 +77,8 @@ func TestTag(t *testing.T) {
 		},
 		"feature branch into develop": {
 			CurrentBranch: "develop",
-			LatestTag:     "0.2.1",
-			SourceBranch:  "feature/semver-initial",
+			LatestTag:     "v0.2.1",
+			SourceBranch:  "feature/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",
@@ -94,8 +95,8 @@ func TestTag(t *testing.T) {
 		},
 		"misc branch into develop": {
 			CurrentBranch: "develop",
-			LatestTag:     "0.2.1-alpha.1",
-			SourceBranch:  "misc/semver-initial",
+			LatestTag:     "v0.2.1-alpha.1",
+			SourceBranch:  "misc/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",
@@ -110,9 +111,27 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
+		"hotfix branch into master": {
+			CurrentBranch: "master",
+			LatestTag:     "v0.2.1",
+			SourceBranch:  "hotfix/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				SemverTag:    "v0.2.2",
+				IsPrerelease: false,
+			},
+		},
 		"merge develop into master": {
 			CurrentBranch: "master",
-			LatestTag:     "1.4.17-alpha.1",
+			LatestTag:     "v1.4.17-alpha.1",
 			SourceBranch:  "develop",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -130,7 +149,7 @@ func TestTag(t *testing.T) {
 		},
 		"merge develop into master with previous matching tag": {
 			CurrentBranch: "master",
-			LatestTag:     "1.4.17-alpha.1",
+			LatestTag:     "v1.4.17-alpha.1",
 			AncestorTag:   "v1.4.16",
 			SourceBranch:  "develop",
 			Params: generate.Params{
@@ -148,9 +167,29 @@ func TestTag(t *testing.T) {
 				IsPrerelease: false,
 			},
 		},
+		"resync branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "v1.3.0-alpha.1",
+			AncestorTag:   "v1.2.0-alpha.2",
+			SourceBranch:  "resync/master",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v1.3.0-alpha.1",
+				AncestorTag:  "v1.2.0-alpha.2",
+				SemverTag:    "v1.3.1-alpha.1",
+				IsPrerelease: true,
+			},
+		},
 		"base version set": {
 			CurrentBranch: "develop",
-			LatestTag:     "2.6.19",
+			LatestTag:     "v2.6.19",
 			SourceBranch:  "feature/semver-initial",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -169,7 +208,7 @@ func TestTag(t *testing.T) {
 		},
 		"invalid branch name": {
 			CurrentBranch: "develop",
-			LatestTag:     "2.6.19-alpha.1",
+			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -187,7 +226,7 @@ func TestTag(t *testing.T) {
 		},
 		"force bump major": {
 			CurrentBranch: "develop",
-			LatestTag:     "2.6.19-alpha.1",
+			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -205,7 +244,7 @@ func TestTag(t *testing.T) {
 		},
 		"force bump minor": {
 			CurrentBranch: "develop",
-			LatestTag:     "2.6.19-alpha.1",
+			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -223,7 +262,7 @@ func TestTag(t *testing.T) {
 		},
 		"force bump patch": {
 			CurrentBranch: "develop",
-			LatestTag:     "2.6.19-alpha.1",
+			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -280,13 +319,19 @@ type gitClientMock struct {
 	IsRepoFnInvoked        int
 	LatestTagFn            func() string
 	LatestTagFnInvoked     int
-	AncestorTagFn          func(include, exclude string) string
+	AncestorTagFn          func(include, branch string) string
 	AncestorTagFnInvoked   int
 	SourceBranchFn         func(commitHash string) (string, error)
 	SourceBranchFnInvoked  int
 }
 
-func initGitClientMock(t *testing.T, latestTag, ancestorTag, currentBranch, sourceBranch, expectedCommitHash string) *gitClientMock {
+func initGitClientMock(
+	t *testing.T,
+	latestTag,
+	ancestorTag,
+	currentBranch,
+	sourceBranch,
+	expectedCommitHash string) *gitClientMock {
 	return &gitClientMock{
 		CurrentBranchFn: func() (string, error) {
 			return currentBranch, nil
@@ -297,7 +342,7 @@ func initGitClientMock(t *testing.T, latestTag, ancestorTag, currentBranch, sour
 		LatestTagFn: func() string {
 			return latestTag
 		},
-		AncestorTagFn: func(include, exclude string) string {
+		AncestorTagFn: func(include, branch string) string {
 			return ancestorTag
 		},
 		SourceBranchFn: func(commitHash string) (string, error) {
@@ -321,9 +366,9 @@ func (m *gitClientMock) LatestTag() string {
 	return m.LatestTagFn()
 }
 
-func (m *gitClientMock) AncestorTag(include, exclude string) string {
+func (m *gitClientMock) AncestorTag(include, branch string) string {
 	m.AncestorTagFnInvoked += 1
-	return m.AncestorTagFn(include, exclude)
+	return m.AncestorTagFn(include, branch)
 }
 
 func (m *gitClientMock) SourceBranch(commitHash string) (string, error) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -133,8 +133,8 @@ func (c *Client) LatestTag() string {
 }
 
 // AncestorTag returns the previous tag that matches specific pattern if found.
-func (c *Client) AncestorTag(include, exclude string) string {
-	result, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, "--exclude", exclude))
+func (c *Client) AncestorTag(include, branch string) string {
+	result, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, branch))
 	if result == "" {
 		result, _ = c.Clean(c.Run("-C", c.repoDir, "rev-list", "--max-parents=0", "HEAD"))
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -145,16 +145,17 @@ func TestLatestTag_NoTagFound(t *testing.T) {
 func TestAncestorTag(t *testing.T) {
 	tests := map[string]struct {
 		IncludePattern string
-		ExcludePattern string
+		Branch         string
 		ExpectedTag    string
 	}{
 		"dev tag only": {
 			IncludePattern: "v[0-9]*-dev*",
+			Branch:         "develop",
 			ExpectedTag:    "v0.11.1-dev.2",
 		},
 		"non-dev tag only": {
 			IncludePattern: "v[0-9]*",
-			ExcludePattern: "v[0-9]*-dev*",
+			Branch:         "master",
 			ExpectedTag:    "v1.2.0",
 		},
 	}
@@ -164,12 +165,12 @@ func TestAncestorTag(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gc.GitCmd = func(env map[string]string, args ...string) (string, error) {
 				assert.Nil(t, env)
-				assert.Equal(t, args, []string{"-C", "/path/to/repo", "describe", "--tags", "--abbrev=0", "--match", args[6], "--exclude", args[8]})
+				assert.Equal(t, args, []string{"-C", "/path/to/repo", "describe", "--tags", "--abbrev=0", "--match", args[6], args[7]})
 
 				return test.ExpectedTag, nil
 			}
 
-			value := gc.AncestorTag(test.IncludePattern, test.ExcludePattern)
+			value := gc.AncestorTag(test.IncludePattern, test.Branch)
 
 			assert.Equal(t, test.ExpectedTag, value)
 		})
@@ -187,7 +188,7 @@ func TestAncestorTag_NoTagFound(t *testing.T) {
 
 		switch numCalls {
 		case 1:
-			assert.Equal(t, args, []string{"-C", "/path/to/repo", "describe", "--tags", "--abbrev=0", "--match", args[6], "--exclude", args[8]})
+			assert.Equal(t, args, []string{"-C", "/path/to/repo", "describe", "--tags", "--abbrev=0", "--match", args[6], args[7]})
 		case 2:
 			assert.Equal(t, args, []string{"-C", "/path/to/repo", "rev-list", "--max-parents=0", "HEAD"})
 		}


### PR DESCRIPTION
This PR adds a new conditional for `resync` prefix. It will allow to resync/update `develop` branch when a hotfix is done at `master`. A new branch must be suffixed with `resync/*`.

- As we've been using the letter `v` as prefix for tags, semver allows to parse tolerant. So I replaced `Parse` by `ParseTolerant`. Less code :)
- Small improvement in the tests by suffixing with `v` all string versions

Closes https://github.com/wakatime/semver-action/issues/8