### PR TITLE
Use correct pre-release version for doc and misc branches

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -60,6 +60,7 @@ func TestTag(t *testing.T) {
 		"doc branch into develop": {
 			CurrentBranch: "develop",
 			LatestTag:     "v0.2.1-alpha.1",
+			AncestorTag:   "v0.2.0-alpha.1",
 			SourceBranch:  "doc/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -71,7 +72,28 @@ func TestTag(t *testing.T) {
 			},
 			Result: generate.Result{
 				PreviousTag:  "v0.2.1-alpha.1",
+				AncestorTag:  "v0.2.0-alpha.1",
 				SemverTag:    "v0.2.1-alpha.2",
+				IsPrerelease: true,
+			},
+		},
+		"doc branch into develop when latest tag is equal to ancestor develop tag excluding pre-release part": {
+			CurrentBranch: "develop",
+			LatestTag:     "v0.2.1",
+			AncestorTag:   "v0.2.1-alpha.2",
+			SourceBranch:  "doc/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				AncestorTag:  "v0.2.1-alpha.2",
+				SemverTag:    "v0.2.1-alpha.3",
 				IsPrerelease: true,
 			},
 		},
@@ -114,6 +136,7 @@ func TestTag(t *testing.T) {
 		"misc branch into develop": {
 			CurrentBranch: "develop",
 			LatestTag:     "v0.2.1-alpha.1",
+			AncestorTag:   "v0.2.0-alpha.1",
 			SourceBranch:  "misc/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
@@ -125,6 +148,7 @@ func TestTag(t *testing.T) {
 			},
 			Result: generate.Result{
 				PreviousTag:  "v0.2.1-alpha.1",
+				AncestorTag:  "v0.2.0-alpha.1",
 				SemverTag:    "v0.2.1-alpha.2",
 				IsPrerelease: true,
 			},


### PR DESCRIPTION
This PR checks if source branch is prefixed with `doc` or `misc` and the target branch is develop to correctly set pre-release version based on the ancestor `develop` tag. It will fixes cases where the latest tag is `v1.6.0` and the ancestor develop tag has the same base version like `v1.6.0-alpha.1`, `v1.6.0-alpha.2` and so on.

Current implementation
- v1.6.0-alpha.1 **<- generated semver tag** - Conflicts with previous
- v1.6.0 **<- latest tag**
- v1.6.0-alpha.2 **<- ancestor develop tag**
- v1.6.0-alpha.1
- v1.5.0

New implementation
- v1.6.0-alpha.3 **<- generated semver tag**
- v1.6.0 **<- latest tag**
- v1.6.0-alpha.2 **<- ancestor develop tag**
- v1.6.0-alpha.1
- v1.5.0