### PR TITLE
Add back exclude pattern for ancestor tag

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -361,7 +361,7 @@ type gitClientMock struct {
 	IsRepoFnInvoked        int
 	LatestTagFn            func() string
 	LatestTagFnInvoked     int
-	AncestorTagFn          func(include, branch string) string
+	AncestorTagFn          func(include, exclude, branch string) string
 	AncestorTagFnInvoked   int
 	SourceBranchFn         func(commitHash string) (string, error)
 	SourceBranchFnInvoked  int
@@ -384,7 +384,7 @@ func initGitClientMock(
 		LatestTagFn: func() string {
 			return latestTag
 		},
-		AncestorTagFn: func(include, branch string) string {
+		AncestorTagFn: func(include, exclude, branch string) string {
 			return ancestorTag
 		},
 		SourceBranchFn: func(commitHash string) (string, error) {
@@ -408,9 +408,9 @@ func (m *gitClientMock) LatestTag() string {
 	return m.LatestTagFn()
 }
 
-func (m *gitClientMock) AncestorTag(include, branch string) string {
+func (m *gitClientMock) AncestorTag(include, exclude, branch string) string {
 	m.AncestorTagFnInvoked += 1
-	return m.AncestorTagFn(include, branch)
+	return m.AncestorTagFn(include, exclude, branch)
 }
 
 func (m *gitClientMock) SourceBranch(commitHash string) (string, error) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -133,8 +133,8 @@ func (c *Client) LatestTag() string {
 }
 
 // AncestorTag returns the previous tag that matches specific pattern if found.
-func (c *Client) AncestorTag(include, branch string) string {
-	result, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, branch))
+func (c *Client) AncestorTag(include, exclude, branch string) string {
+	result, _ := c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", "--abbrev=0", "--match", include, "--exclude", exclude, branch))
 	if result == "" {
 		result, _ = c.Clean(c.Run("-C", c.repoDir, "rev-list", "--max-parents=0", "HEAD"))
 	}


### PR DESCRIPTION
This PR adds back the exclude pattern to ancestor tag function. It's mandatory to avoid getting pre-release tags when running ancestor tag for master branch.

The correct return should be `v1.6.0` for ancestor tag.
<img width="251" alt="Screen Shot 2021-05-20 at 12 57 39" src="https://user-images.githubusercontent.com/782854/119011017-9d2f7a00-b962-11eb-973a-1a9c5980e62e.png">