### PR TITLE
Fix get latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These are the prefixes we expect when `auto` bump:
 
 #### Auto Bump
 
-- Not a valid source branch prefix - Increments pre-release version.
+- Not a valid source branch prefix - Increments prerelease version.
 
     ```text
         v0.1.0 results in v0.1.0-pre.1
@@ -117,7 +117,7 @@ Uses `auto` bump strategy to calculate the next semantic version.
 | bump                |          | Bump strategy for semantic versioning. Can be `auto`, `major`, `minor`, `patch`. | auto        |
 | base_version        |          | Version to use as base for the generation, skips version bumps.                  |             |
 | prefix              |          | Prefix used to prepend the final version.                                        | v           |
-| prerelease_id       |          | Text representing the pre-release identifier.                                    | pre         |
+| prerelease_id       |          | Text representing the prerelease identifier.                                    | pre         |
 | main_branch_name    |          | The main branch name.                                                            | master      |
 | develop_branch_name |          | The develop branch name.                                                         | develop     |
 | repo_dir            |          | The repository path.                                                             | current dir |
@@ -128,6 +128,6 @@ Uses `auto` bump strategy to calculate the next semantic version.
 | parameter     | description                                      |
 | ---           | ---                                              |
 | semver_tag    | The calculdated semantic version.                |
-| is_prerelease | True if calculated tag is pre-release.           |
+| is_prerelease | True if calculated tag is prerelease.           |
 | previous_tag  | The tag used to calculate next semantic version. |
 | ancestor_tag  | The ancestor tag based on specific pattern.      |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: 'v'
     required: false
   prerelease_id:
-    description: 'Text representing the pre-release identifier'
+    description: 'Text representing the prerelease identifier'
     default: 'pre'
     required: false
   main_branch_name:
@@ -42,7 +42,7 @@ outputs:
   semver_tag:
     description: 'The calculdated semantic version'
   is_prerelease:
-    description: 'True if calculated tag is pre-release'
+    description: 'True if calculated tag is prerelease'
   previous_tag:
     description: 'The tag used to calculate next semantic version'
   ancestor_tag:

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -89,9 +89,7 @@ func Tag(params Params, gc gitClient) (Result, error) {
 
 	log.Debugf("method: %q, version: %q", method, version)
 
-	var (
-		tag *semver.Version
-	)
+	var tag *semver.Version
 
 	latestTag := gc.LatestTag()
 	if latestTag == "" {
@@ -132,7 +130,7 @@ func Tag(params Params, gc gitClient) (Result, error) {
 	}
 
 	// If branch is prefixed with doc or misc and the latest tag is equal to the
-	// ancestor develop tag excluding pre-release part, then it will use ancestor one instead.
+	// ancestor develop tag excluding prerelease part, then it will use ancestor one instead.
 	if (branchDocPrefixRegex.MatchString(source) || branchMiscPrefixRegex.MatchString(source)) &&
 		dest == params.DevelopBranchName {
 		ancestorDevelopTag := gc.AncestorTag(
@@ -174,7 +172,7 @@ func Tag(params Params, gc gitClient) (Result, error) {
 
 			preVersion, err := semver.NewPRVersion(params.PrereleaseID)
 			if err != nil {
-				return Result{}, fmt.Errorf("failed to create new pre-release version: %s", err)
+				return Result{}, fmt.Errorf("failed to create new prerelease version: %s", err)
 			}
 
 			tag.Pre = append(tag.Pre, preVersion)

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -77,7 +77,7 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
-		"doc branch into develop when latest tag is equal to ancestor develop tag excluding pre-release part": {
+		"doc branch into develop when latest tag is equal to ancestor develop tag excluding prerelease part": {
 			CurrentBranch: "develop",
 			LatestTag:     "v0.2.1",
 			AncestorTag:   "v0.2.1-alpha.2",

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -125,9 +125,14 @@ func (c *Client) SourceBranch(commitHash string) (string, error) {
 
 // LatestTag returns the latest tag if found.
 func (c *Client) LatestTag() string {
-	result, _ := c.Clean(c.Run("-C", c.repoDir, "tag", "--sort", "-version:creatordate"))
+	var result string
 
-	return strings.Split(result, "\n")[0]
+	commitSha, _ := c.Clean(c.Run("-C", c.repoDir, "rev-list", "--tags", "--max-count=1"))
+	if commitSha != "" {
+		result, _ = c.Clean(c.Run("-C", c.repoDir, "describe", "--tags", commitSha))
+	}
+
+	return result
 }
 
 // AncestorTag returns the previous tag that matches specific pattern if found.

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -105,10 +105,21 @@ func TestSourceBranch_NotValiddBranchName(t *testing.T) {
 }
 
 func TestLatestTag(t *testing.T) {
+	var numCalls int
+
 	gc := git.NewGit("/path/to/repo")
 	gc.GitCmd = func(env map[string]string, args ...string) (string, error) {
+		numCalls++
+
 		assert.Nil(t, env)
-		assert.Equal(t, args, []string{"-C", "/path/to/repo", "tag", "--sort", "-version:creatordate"})
+
+		switch numCalls {
+		case 1:
+			assert.Equal(t, args, []string{"-C", "/path/to/repo", "rev-list", "--tags", "--max-count=1"})
+			return "da81ce0ec20cab645ffe03e760dad1cdfccf7c94", nil
+		case 2:
+			assert.Equal(t, args, []string{"-C", "/path/to/repo", "describe", "--tags", "da81ce0ec20cab645ffe03e760dad1cdfccf7c94"})
+		}
 
 		return "v2.4.79", nil
 	}
@@ -122,7 +133,7 @@ func TestLatestTag_NoTagFound(t *testing.T) {
 	gc := git.NewGit("/path/to/repo")
 	gc.GitCmd = func(env map[string]string, args ...string) (string, error) {
 		assert.Nil(t, env)
-		assert.Equal(t, args, []string{"-C", "/path/to/repo", "tag", "--sort", "-version:creatordate"})
+		assert.Equal(t, args, []string{"-C", "/path/to/repo", "rev-list", "--tags", "--max-count=1"})
 
 		return "", nil
 	}


### PR DESCRIPTION
This PR fixes latest tag function to properly return latest valid tag.

Fixes https://github.com/wakatime/wakatime-cli/runs/3519989204?check_suite_focus=true