### PR TITLE
Parse upstream branches

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -13,13 +13,13 @@ import (
 
 // nolint: gochecknoglobals
 var (
-	branchBugfixPrefixRegex  = regexp.MustCompile(`(?i)^bugfix/.+`)
-	branchDocPrefixRegex     = regexp.MustCompile(`(?i)^docs?/.+`)
-	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^feature/.+`)
-	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^hotfix/.+`)
-	branchMajorPrefixRegex   = regexp.MustCompile(`(?i)^major/.+`)
-	branchMiscPrefixRegex    = regexp.MustCompile(`(?i)^misc/.+`)
-	branchResyncPrefixRegex  = regexp.MustCompile(`(?i)^resync/.+`)
+	branchBugfixPrefixRegex  = regexp.MustCompile(`(?i)^(.+:)?(bugfix/.+)`)
+	branchDocPrefixRegex     = regexp.MustCompile(`(?i)^(.+:)?(docs?/.+)`)
+	branchFeaturePrefixRegex = regexp.MustCompile(`(?i)^(.+:)?(feature/.+)`)
+	branchHotfixPrefixRegex  = regexp.MustCompile(`(?i)^(.+:)?(hotfix/.+)`)
+	branchMajorPrefixRegex   = regexp.MustCompile(`(?i)^(.+:)?(major/.+)`)
+	branchMiscPrefixRegex    = regexp.MustCompile(`(?i)^(.+:)?(misc/.+)`)
+	branchResyncPrefixRegex  = regexp.MustCompile(`(?i)^(.+:)?(resync/.+)`)
 )
 
 const tagDefault = "0.0.0"
@@ -74,7 +74,7 @@ func Tag(params Params, gc gitClient) (Result, error) {
 
 	dest, err := gc.CurrentBranch()
 	if err != nil {
-		return Result{}, fmt.Errorf("failed to extract dest branche from commit: %s", err)
+		return Result{}, fmt.Errorf("failed to extract dest branch from commit: %s", err)
 	}
 
 	log.Debugf("dest branch: %q\n", dest)

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -115,10 +115,46 @@ func TestTag(t *testing.T) {
 				IsPrerelease: true,
 			},
 		},
+		"upstream feature branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "v0.2.1",
+			SourceBranch:  "some-user:feature/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				SemverTag:    "v0.3.0-alpha.1",
+				IsPrerelease: true,
+			},
+		},
 		"bugfix branch into develop": {
 			CurrentBranch: "develop",
 			LatestTag:     "v0.2.1",
 			SourceBranch:  "bugfix/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				SemverTag:    "v0.2.2-alpha.1",
+				IsPrerelease: true,
+			},
+		},
+		"upstream bugfix branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "v0.2.1",
+			SourceBranch:  "some-user:bugfix/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",
@@ -138,6 +174,26 @@ func TestTag(t *testing.T) {
 			LatestTag:     "v0.2.1-alpha.1",
 			AncestorTag:   "v0.2.0-alpha.1",
 			SourceBranch:  "misc/some",
+			Params: generate.Params{
+				CommitSha:         "81918ffc",
+				Bump:              "auto",
+				Prefix:            "v",
+				PrereleaseID:      "alpha",
+				MainBranchName:    "master",
+				DevelopBranchName: "develop",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1-alpha.1",
+				AncestorTag:  "v0.2.0-alpha.1",
+				SemverTag:    "v0.2.1-alpha.2",
+				IsPrerelease: true,
+			},
+		},
+		"upstream misc branch into develop": {
+			CurrentBranch: "develop",
+			LatestTag:     "v0.2.1-alpha.1",
+			AncestorTag:   "v0.2.0-alpha.1",
+			SourceBranch:  "some-user:misc/some",
 			Params: generate.Params{
 				CommitSha:         "81918ffc",
 				Bump:              "auto",


### PR DESCRIPTION
This PR adds the functionality to parse branches created into upstream like `some-use:feature/some-feature`.

It won't break pipeline for https://github.com/wakatime/wakatime-cli/pull/560.