### PR TITLE
Make current repo dir safe

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -27,6 +27,7 @@ const tagDefault = "0.0.0"
 type gitClient interface {
 	CurrentBranch() (string, error)
 	IsRepo() bool
+	MakeSafe() error
 	LatestTag() string
 	AncestorTag(include, exclude, branch string) string
 	SourceBranch(commitHash string) (string, error)
@@ -64,6 +65,11 @@ func Run() (Result, error) {
 func Tag(params Params, gc gitClient) (Result, error) {
 	if !gc.IsRepo() {
 		return Result{}, fmt.Errorf("current folder is not a git repository")
+	}
+
+	err := gc.MakeSafe()
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to make safe: %s", err)
 	}
 
 	tagSource := "git"

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -79,6 +80,21 @@ func (c *Client) Clean(output string, err error) (string, error) {
 // Run runs a git command and returns its output or errors.
 func (c *Client) Run(args ...string) (string, error) {
 	return c.GitCmd(nil, args...)
+}
+
+// MakeSafe adds safe.directory global config.
+func (c *Client) MakeSafe() error {
+	dir, err := filepath.Abs(c.repoDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for: %s", c.repoDir)
+	}
+
+	_, err = c.Run("config", "--global", "--add", "safe.directory", dir)
+	if err != nil {
+		return fmt.Errorf("failed to set safe current directory")
+	}
+
+	return nil
 }
 
 // IsRepo returns true if current folder is a git repository.


### PR DESCRIPTION
This PR fixes repository being considered unsafe somehow.

```
unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```